### PR TITLE
adapt to changes in capybara, smoke tested in 1.1.2

### DIFF
--- a/lib/send-keys/support/send_keys.rb
+++ b/lib/send-keys/support/send_keys.rb
@@ -62,8 +62,8 @@ module SendKeys
       end
     end
    
-    node.send_keys(send_key)
+    native.send_keys(send_key)
   end
 end
 
-Capybara::Node.send :include, SendKeys
+Capybara::Node::Base.send :include, SendKeys


### PR DESCRIPTION
Capybara::Node#node does not exist anymore in 1.1.2
